### PR TITLE
dependaupdates (#62)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'org.apache.commons:commons-compress:1.26.1' // included due to vuln in avro
     implementation 'org.apache.poi:poi-ooxml:5.2.5'
     implementation 'org.apache.kafka:kafka-streams:3.7.0'
-    implementation 'org.springframework.kafka:spring-kafka:3.1.4'
+    implementation 'org.springframework.kafka:spring-kafka:3.2.3'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
@@ -39,13 +39,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework:spring-jdbc:6.1.11'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    implementation 'org.springframework.security:spring-security-core:6.2.4'
+    implementation 'org.springframework.security:spring-security-core:6.3.3'
 
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.oracle.database.jdbc:ojdbc11:23.3.0.23.09'
     implementation 'com.h2database:h2:2.2.224'
     implementation 'com.thoughtworks.xstream:xstream:1.4.20'
-    implementation 'net.datafaker:datafaker:2.2.2'
+    implementation 'net.datafaker:datafaker:2.3.1'
 
     implementation 'com.okta.spring:okta-spring-boot-starter:3.0.6'
     implementation 'org.webjars:webjars-locator:0.52'
@@ -58,7 +58,7 @@ dependencies {
     implementation 'org.webjars:sockjs-client:1.5.1'
     implementation 'org.webjars:momentjs:2.29.4'
     implementation 'org.webjars.npm:chart.js:4.4.2'
-    implementation 'org.webjars.npm:dompurify:3.1.1'
+    implementation 'org.webjars.npm:dompurify:3.1.6'
     implementation 'org.webjars:jszip:3.10.1'
     implementation 'org.webjars.bower:pdfmake:0.2.7'
 
@@ -66,7 +66,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.32'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation platform('org.junit:junit-bom:5.10.2')
+    testImplementation platform('org.junit:junit-bom:5.11.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core:3.25.3'
 }


### PR DESCRIPTION
* Bump org.springframework.kafka:spring-kafka from 3.1.4 to 3.2.3 (#57)

Bumps [org.springframework.kafka:spring-kafka](https://github.com/spring-projects/spring-kafka) from 3.1.4 to 3.2.3.
- [Release notes](https://github.com/spring-projects/spring-kafka/releases)
- [Commits](https://github.com/spring-projects/spring-kafka/compare/v3.1.4...v3.2.3)

---
updated-dependencies:
- dependency-name: org.springframework.kafka:spring-kafka dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump org.junit:junit-bom from 5.10.2 to 5.11.0 (#61)

Bumps [org.junit:junit-bom](https://github.com/junit-team/junit5) from 5.10.2 to 5.11.0.
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.10.2...r5.11.0)

---
updated-dependencies:
- dependency-name: org.junit:junit-bom dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump net.datafaker:datafaker from 2.2.2 to 2.3.1 (#60)

Bumps [net.datafaker:datafaker](https://github.com/datafaker-net/datafaker) from 2.2.2 to 2.3.1.
- [Commits](https://github.com/datafaker-net/datafaker/compare/v2.2.2...v2.3.1)

---
updated-dependencies:
- dependency-name: net.datafaker:datafaker dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump org.springframework.security:spring-security-core (#59)

Bumps [org.springframework.security:spring-security-core](https://github.com/spring-projects/spring-security) from 6.2.4 to 6.3.3.
- [Release notes](https://github.com/spring-projects/spring-security/releases)
- [Changelog](https://github.com/spring-projects/spring-security/blob/main/RELEASE.adoc)
- [Commits](https://github.com/spring-projects/spring-security/compare/6.2.4...6.3.3)

---
updated-dependencies:
- dependency-name: org.springframework.security:spring-security-core dependency-type: direct:production update-type: version-update:semver-minor ...




* Bump org.webjars.npm:dompurify from 3.1.1 to 3.1.6 (#58)

Bumps [org.webjars.npm:dompurify](https://github.com/cure53/DOMPurify) from 3.1.1 to 3.1.6.
- [Release notes](https://github.com/cure53/DOMPurify/releases)
- [Commits](https://github.com/cure53/DOMPurify/compare/3.1.1...3.1.6)

---
updated-dependencies:
- dependency-name: org.webjars.npm:dompurify dependency-type: direct:production update-type: version-update:semver-patch ...




---------